### PR TITLE
Remove have_library('ruby')

### DIFF
--- a/ext/magic/extconf.rb
+++ b/ext/magic/extconf.rb
@@ -84,8 +84,6 @@ unless have_header('ruby.h')
   EOS
 end
 
-have_library('ruby')
-
 have_func('rb_thread_call_without_gvl')
 have_func('rb_thread_blocking_region')
 


### PR DESCRIPTION
I believe this has potential to link against the wrong library. With this line on macos Catalina I get:

    `require_relative': incompatible library version - magic.bundle (LoadError)