### PR TITLE
Use mini_portile2 to build libmagic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ env:
     - COMPILER=clang
     - COMPILER=gcc RAKE_COMPILER_OPTIONS="-- --disable-static"
     - COMPILER=clang RAKE_COMPILER_OPTIONS="-- --disable-static"
+    - COMPILER=gcc RAKE_COMPILER_OPTIONS="-- --use-system-libraries"
+    - COMPILER=clang RAKE_COMPILER_OPTIONS="-- --use-system-libraries"
 
 matrix:
   fast_finish: true
@@ -40,6 +42,7 @@ before_install:
   - bundle config set --local path 'vendor/bundle'
   - bundle config set --local without 'development'
   - export CC="$(which $COMPILER)"
+  - if [[ $RAKE_COMPILER_OPTIONS =~ use-system-libraries ]]; then sudo apt update && sudo apt install libmagic1 libmagic-dev; fi
 
 before_script:
   - export CFLAGS="-I${PREFIX}/include" LDFLAGS="-L${PREFIX}/lib"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ env:
   matrix:
     - COMPILER=gcc
     - COMPILER=clang
+    - COMPILER=gcc RAKE_COMPILER_OPTIONS="-- --disable-static"
+    - COMPILER=clang RAKE_COMPILER_OPTIONS="-- --disable-static"
 
 matrix:
   fast_finish: true
@@ -45,5 +47,5 @@ before_script:
   - bundle exec rake clean
 
 script:
-  - bundle exec rake compile
+  - bundle exec rake compile $RAKE_COMPILER_OPTIONS
   - bundle exec rake test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-dist: xenial
+dist: bionic
 
 cache:
   bundler: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,8 +45,6 @@ before_install:
   - if [[ $RAKE_COMPILER_OPTIONS =~ use-system-libraries ]]; then sudo apt update && sudo apt install libmagic1 libmagic-dev; fi
 
 before_script:
-  - export CFLAGS="-I${PREFIX}/include" LDFLAGS="-L${PREFIX}/lib"
-  - export LD_LIBRARY_PATH="${PREFIX}/lib"
   - bundle exec rake clean
 
 script:

--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,11 @@ CLEAN.include FileList['**/*{.o,.so,.bundle,.log}'],
               FileList['**/Makefile']
 
 CLOBBER.include FileList['lib/**/*.so'],
-                FileList['doc/**/*']
+                FileList['doc/**/*'],
+                FileList['tmp/'],
+                FileList['ext/magic/extconf.h'],
+                FileList['ext/magic/tmp'],
+                FileList['ports/']
 
 gem = eval File.read('ruby-magic.gemspec')
 

--- a/ext/magic/extconf.rb
+++ b/ext/magic/extconf.rb
@@ -70,14 +70,20 @@ def process_recipe(name, version, static_p, cross_p)
 
     recipe.configure_options.flatten!
 
+    recipe.configure_options = [
+      "--disable-silent-rules",
+      "--disable-dependency-tracking",
+      "--enable-fsect-man5"
+    ]
+
     if static_p
-      recipe.configure_options = [
+      recipe.configure_options += [
         "--disable-shared",
         "--enable-static",
       ]
       env["CFLAGS"] = concat_flags(env["CFLAGS"], "-fPIC")
     else
-      recipe.configure_options = [
+      recipe.configure_options += [
         "--enable-shared",
         "--disable-static",
       ]

--- a/ext/magic/extconf.rb
+++ b/ext/magic/extconf.rb
@@ -187,10 +187,14 @@ def do_clean
 
     FileUtils.rm_rf(root + 'ports' + 'archives', verbose: true)
 
-    if config_static?
-      # Remove everything but share/ directory
-      Find.find(root + 'ports').each do |filename|
-        FileUtils.rm_f(filename, verbose: true) unless filename.include?('/share')
+    # Remove everything but share/ directory
+    remove_paths = %w[bin include]
+    remove_paths << 'lib' if config_static?
+
+    Pathname.glob(File.join(root, 'ports', '*', 'libmagic', '*')) do |dir|
+      remove_paths.each do |path|
+        remove_dir = File.join(dir, path)
+        FileUtils.rm_rf(remove_dir, verbose: true)
       end
     end
   end

--- a/ext/magic/extconf.rb
+++ b/ext/magic/extconf.rb
@@ -229,13 +229,12 @@ else
 
   $LIBPATH = [File.join(libmagic_recipe.path, 'lib')]
   $CFLAGS << " -I#{File.join(libmagic_recipe.path, 'include')} "
+  $LDFLAGS += " -Wl,-rpath,#{libmagic_recipe.path}/lib"
 
   if static_p
     ENV['PKG_CONFIG_PATH'] = "#{libmagic_recipe.path}/lib/pkgconfig"
     # mkmf appends -- to the first option
     $LIBS += " " + pkg_config('libmagic', 'libs --static')
-    $LDFLAGS.gsub!('-lmagic', '')
-    $LIBS.gsub!('-lmagic', '')
     $LIBS += " " + File.join(libmagic_recipe.path, 'lib', "libmagic.#{$LIBEXT}")
   end
 end

--- a/ruby-magic.gemspec
+++ b/ruby-magic.gemspec
@@ -49,4 +49,6 @@ Gem::Specification.new do |s|
 
   s.cert_chain  = [ 'kwilczynski-public.pem' ]
   s.signing_key = signing_key if File.exist?(signing_key)
+
+  s.add_runtime_dependency("mini_portile2", "~> 2.5.0") # keep version in sync with extconf.rb
 end

--- a/test/test_magic.rb
+++ b/test/test_magic.rb
@@ -55,7 +55,13 @@ class MagicTest < Test::Unit::TestCase
   end
 
   def test_magic_new_instance_default_flags
-    assert_equal(0, @magic.flags)
+    # If libmagic needs to search more than one path, it will enable the CHECK flag.
+    # See https://github.com/kwilczynski/ruby-magic/pull/5#issuecomment-808686480
+    if @magic.paths.length > 1
+      assert_equal(Magic::CHECK, @magic.flags)
+    else
+      assert_equal(Magic::NONE, @magic.flags)
+    end
   end
 
   def test_magic_new_with_block


### PR DESCRIPTION
This pull request introduces significant changes to the build process:

- Use `mini_portile2` gem to build the C extension.
- Clean up unneeded files after build.
- Switch the download archive to pull from the S3 endpoint.
- By default, build a static library of `libmagic` and link it.
- Support disabling of static library generation via the `--disable-static` argument.
- Support for using the system library via the `--use-system-libraries` argument.
- Update Travis CI to use Ubuntu 18.04 (bionic) instead of 16.04 (xenial).

This pull request lifts much of the [`extconf.rb` code from Nokogiri](https://github.com/sparklemotion/nokogiri/blob/main/ext/nokogiri/extconf.rb).

