### PR TITLE
Fix 412 when downloading file from fossies

### DIFF
--- a/ext/magic/extconf.rb
+++ b/ext/magic/extconf.rb
@@ -19,7 +19,7 @@ filename = "#{workdir}/file.tar.gz"
 
 unless File.exist?(filename)
   File.open(filename, 'wb') do |target_file|
-    URI.open("https://fossies.org/linux/misc/file-#{LIBMAGIC_TAG}.tar.gz", 'rb') do |read_file|
+    URI.open("https://fossies.org/linux/misc/file-#{LIBMAGIC_TAG}.tar.gz", "User-Agent" => "RubyMagic") do |read_file|
       target_file.write(read_file.read)
     end
   end

--- a/ext/magic/extconf.rb
+++ b/ext/magic/extconf.rb
@@ -19,7 +19,7 @@ filename = "#{workdir}/file.tar.gz"
 
 unless File.exist?(filename)
   File.open(filename, 'wb') do |target_file|
-    URI.open("https://fossies.org/linux/misc/file-#{LIBMAGIC_TAG}.tar.gz", "User-Agent" => "RubyMagic") do |read_file|
+    URI.open("https://fossies.org/linux/misc/file-#{LIBMAGIC_TAG}.tar.gz", "User-Agent" => "RubyMagic/#{RUBY_DESCRIPTION}") do |read_file|
       target_file.write(read_file.read)
     end
   end


### PR DESCRIPTION
This commit fixes the `OpenURI::HTTPError` when the `gem install ruby-magic` runs.

It looks like `User-Agent` must be specified when the system downloads a file from fossies.

Confirmed in the following test script:

```
[21] pry(main)> File.open(filename, 'wb') do |target_file|
[21] pry(main)*   URI.open("https://fossies.org/linux/misc/file-#{LIBMAGIC_TAG}.tar.gz", 'rb') do |read_file|  
[21] pry(main)*     target_file.write(read_file.read)    
[21] pry(main)*   end    
[21] pry(main)* end  
/home/shinya/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/pry-0.12.2/lib/pry/exceptions.rb:28: warning: $SAFE will become a normal global variable in Ruby 3.0
OpenURI::HTTPError: 412 Precondition Failed
from /home/shinya/.rbenv/versions/2.7.2/lib/ruby/2.7.0/open-uri.rb:387:in `open_http'
```

```
[37] pry(main)> File.open(filename, 'wb') do |target_file|
[37] pry(main)*   URI.open("https://fossies.org/linux/misc/file-#{LIBMAGIC_TAG}.tar.gz", "User-Agent" => "RubyMagic") do |read_file|  
[37] pry(main)*     target_file.write(read_file.read)    
[37] pry(main)*   end    
[37] pry(main)* end  
=> 954266
```