### PR TITLE
Add a test for GC.compact for Ruby 3.0

### DIFF
--- a/test/test_magic.rb
+++ b/test/test_magic.rb
@@ -784,6 +784,14 @@ class MagicTest < Test::Unit::TestCase
     assert_equal(Errno::EINVAL::Errno, error.errno)
   end
 
+  def test_gc_compaction
+    if defined?(GC.verify_compaction_references) == 'method'
+      # This method was added in Ruby 3.0.0. Calling it this way asks the GC to
+      # move objects around, helping to find object movement bugs.
+      GC.verify_compaction_references(double_heap: true, toward: :empty)
+    end
+  end
+
   def test_magic_new_instance_with_arguments
   end
 


### PR DESCRIPTION
This helps flag global pointers that have moved via the compacting
garbage collector in Ruby 2.7 and up.