### PR TITLE
Fix compilation when shared libraries not enabled with Ruby interpreter

### DIFF
--- a/ext/magic/extconf.rb
+++ b/ext/magic/extconf.rb
@@ -272,7 +272,7 @@ end.each do |flag|
 end
 
 unless darwin?
-  $LDFLAGS += ' -Wl,--as-needed -Wl,--no-undefined -Wl,--exclude-libs,ALL'
+  $LDFLAGS += ' -Wl,--as-needed -Wl,--exclude-libs,ALL'
 end
 
 if windows?


### PR DESCRIPTION
The linker flag `-Wl,--no-undefined` was causing ruby-magic compilation
to fail with undefined refrences to Ruby methods (e.g. `rb_warn`). This
enforcement prevented ruby-magic from being compiled with a Ruby
interpreter that did not have `--enabled-shared` set up by default.

Closes #6