### PR TITLE
package dependencies as tarballs

### DIFF
--- a/ruby-magic.gemspec
+++ b/ruby-magic.gemspec
@@ -41,6 +41,7 @@ Gem::Specification.new do |s|
               LICENSE
               NOTICE
               README.md
+              dependencies.yml
               kwilczynski-public.pem
             )
 

--- a/ruby-magic.gemspec
+++ b/ruby-magic.gemspec
@@ -1,5 +1,8 @@
 signing_key = File.expand_path('~/.gem/kwilczynski-private.pem')
 
+require 'yaml'
+dependencies = YAML.load_file(File.join(File.dirname(__FILE__), "dependencies.yml"))
+
 Gem::Specification.new do |s|
   s.name    = 'ruby-magic'
   s.summary = 'File Magic in Ruby'
@@ -43,7 +46,10 @@ Gem::Specification.new do |s|
               README.md
               dependencies.yml
               kwilczynski-public.pem
-            )
+            ) + [
+              File.join("ports", "archives", "file-#{dependencies["libmagic"]["version"]}.tar.gz"),
+            ]
+
 
   s.require_paths << 'lib'
   s.extensions << 'ext/magic/extconf.rb'

--- a/ruby-magic.gemspec
+++ b/ruby-magic.gemspec
@@ -48,8 +48,8 @@ Gem::Specification.new do |s|
               kwilczynski-public.pem
             ) + [
               File.join("ports", "archives", "file-#{dependencies["libmagic"]["version"]}.tar.gz"),
-            ]
-
+            ] +
+            Dir['patches/**/*.patch']
 
   s.require_paths << 'lib'
   s.extensions << 'ext/magic/extconf.rb'


### PR DESCRIPTION
Following up on the conversation at #8, this PR introduces the tarball as a file in the gemspec, so that it's delivered as part of the gem file download from rubygems.org.

mini_portile is smart enough to use this file instead of re-downloading it, which will be a better experience for users and save hosting costs for this project.
