### PR TITLE
introduce some support for native gems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ Icon[]
 pkg
 ports
 tmp
+ext/magic/share/

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ gemspec
 
 gem 'rake'
 gem 'rake-compiler'
+gem 'rake-compiler-dock'
 gem 'rdoc'
 
 group :test do

--- a/Rakefile
+++ b/Rakefile
@@ -72,6 +72,10 @@ Rake::ExtensionTask.new('magic', RUBY_MAGIC_GEM_SPEC) do |e|
   e.cross_config_options << "--enable-cross-build"
   e.cross_platform = CROSS_RUBY_PLATFORMS
   e.cross_compiling do |spec|
+    spec.files.reject! { |path| File.fnmatch?('ports/*', path) }
+    spec.files.reject! { |path| File.fnmatch?('patches/*', path) }
+    spec.dependencies.reject! { |dep| dep.name=='mini_portile2' }
+
     db_glob = "ext/magic/share/*.mgc"
     raise "magic files are not present at #{db_glob}" if Dir[db_glob].empty?
     Dir[db_glob].each { |db| spec.files << db }

--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,8 @@ RakeFileUtils.verbose_flag = false
 
 CLEAN.include FileList['**/*{.o,.so,.dylib,.bundle}'],
               FileList['**/extconf.h'],
-              FileList['**/Makefile']
+              FileList['**/Makefile'],
+              FileList['pkg/']
 
 CLOBBER.include FileList['**/tmp'],
                 FileList['**/*.log'],

--- a/Rakefile
+++ b/Rakefile
@@ -17,8 +17,9 @@ CLEAN.include FileList['**/*{.o,.so,.dylib,.bundle}'],
 CLOBBER.include FileList['**/tmp'],
                 FileList['**/*.log'],
                 FileList['doc/**'],
-                FileList['ports/'],
                 FileList['tmp/']
+
+CLOBBER.add("ports/*").exclude(%r{ports/archives$})
 
 RUBY_MAGIC_GEM_SPEC = Gem::Specification.load('ruby-magic.gemspec')
 

--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,8 @@ RakeFileUtils.verbose_flag = false
 CLEAN.include FileList['**/*{.o,.so,.dylib,.bundle}'],
               FileList['**/extconf.h'],
               FileList['**/Makefile'],
-              FileList['pkg/']
+              FileList['pkg/'],
+              FileList['ext/magic/share/']
 
 CLOBBER.include FileList['**/tmp'],
                 FileList['**/*.log'],
@@ -70,6 +71,11 @@ Rake::ExtensionTask.new('magic', RUBY_MAGIC_GEM_SPEC) do |e|
   e.cross_compile = true
   e.cross_config_options << "--enable-cross-build"
   e.cross_platform = CROSS_RUBY_PLATFORMS
+  e.cross_compiling do |spec|
+    db_glob = "ext/magic/share/*.mgc"
+    raise "magic files are not present at #{db_glob}" if Dir[db_glob].empty?
+    Dir[db_glob].each { |db| spec.files << db }
+  end
 end
 
 namespace "gem" do

--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,7 @@ CLOBBER.include FileList['**/tmp'],
                 FileList['ports/'],
                 FileList['tmp/']
 
-gem = Gem::Specification.load('ruby-magic.gemspec')
+RUBY_MAGIC_GEM_SPEC = Gem::Specification.load('ruby-magic.gemspec')
 
 RDoc::Task.new do |d|
   d.title = 'File Magic in Ruby'
@@ -48,12 +48,12 @@ RuboCop::RakeTask.new('lint') do |t|
   t.fail_on_error = false
 end
 
-Gem::PackageTask.new(gem) do |p|
+Gem::PackageTask.new(RUBY_MAGIC_GEM_SPEC) do |p|
   p.need_zip = false
   p.need_tar = false
 end
 
-Rake::ExtensionTask.new('magic', gem) do |e|
+Rake::ExtensionTask.new('magic', RUBY_MAGIC_GEM_SPEC) do |e|
   e.source_pattern = '*.{c,h}'
   e.ext_dir = 'ext/magic'
   e.lib_dir = 'lib/magic'

--- a/ext/magic/extconf.rb
+++ b/ext/magic/extconf.rb
@@ -301,6 +301,14 @@ else
     $LIBS += " " + pkg_config('libmagic', 'libs --static')
     $LIBS += " " + File.join(libmagic_recipe.path, 'lib', "libmagic.#{$LIBEXT}")
   end
+
+  if cross_build_p
+    # database files will be packaged up by the cross-compiling callback in the ExtensionTask
+    to_path = File.join(PACKAGE_ROOT_DIR, "ext/magic/share")
+    FileUtils.rm_rf(to_path, secure: true)
+    FileUtils.mkdir(to_path)
+    FileUtils.cp_r(Dir[File.join(libmagic_recipe.path, 'share/misc/*.mgc')], to_path)
+  end
 end
 
 $CFLAGS += ' -std=c99'

--- a/ext/magic/extconf.rb
+++ b/ext/magic/extconf.rb
@@ -371,6 +371,13 @@ unless have_header('ruby.h')
   EOS
 end
 
+# these are needed for `rb_thread_call_without_gvl` to be properly detected on some linux systems.
+# specifically, rake-compiler-dock's redhat-based image needs these.
+have_library('pthread')
+have_library('rt')
+have_library('dl')
+have_library('crypt')
+
 have_func('rb_thread_call_without_gvl')
 have_func('rb_thread_blocking_region')
 

--- a/ext/magic/ruby-magic.c
+++ b/ext/magic/ruby-magic.c
@@ -299,10 +299,7 @@ rb_mgc_get_paths(VALUE object)
 		return value;
 
 	cstring = magic_getpath_wrapper();
-	value = magic_split(CSTR2RVAL(cstring), CSTR2RVAL(":"));
-	RB_GC_GUARD(value);
-
-	return value;
+	return magic_set_paths(object, magic_split(CSTR2RVAL(cstring), CSTR2RVAL(":")));
 }
 
 /*
@@ -487,14 +484,11 @@ rb_mgc_load(VALUE object, VALUE arguments)
 
 	ma.flags = magic_get_flags(object);
 
-	if (!RARRAY_EMPTY_P(arguments)) {
-		value = magic_join(arguments, CSTR2RVAL(":"));
-		ma.type.file.path = RVAL2CSTR(value);
+	if (RARRAY_EMPTY_P(arguments)) {
+		arguments = rb_mgc_get_paths(object);
 	}
-	else
-		ma.type.file.path = magic_getpath_wrapper();
-
-	magic_set_paths(object, RARRAY_EMPTY);
+	value = magic_join(arguments, CSTR2RVAL(":"));
+	ma.type.file.path = RVAL2CSTR(value);
 
 	MAGIC_SYNCHRONIZED(magic_load_internal, &ma);
 	if (ma.status < 0) {

--- a/lib/magic.rb
+++ b/lib/magic.rb
@@ -181,6 +181,13 @@ class Magic
     end
 
     alias_method :fd, :descriptor
+
+    private
+
+    def default_paths
+      paths = Dir.glob(File.expand_path(File.join(File.dirname(__FILE__), "../ext/magic/share/*.mgc")))
+      paths.empty? ? nil : paths
+    end
   end
 
   private

--- a/lib/magic.rb
+++ b/lib/magic.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
-require_relative 'magic/magic'
+begin
+  ::RUBY_VERSION =~ /(\d+\.\d+)/
+  require_relative "magic/#{Regexp.last_match(1)}/magic"
+rescue LoadError => e
+  require_relative 'magic/magic'
+end
+
 require_relative 'magic/version'
 require_relative 'magic/core/file'
 require_relative 'magic/core/string'

--- a/test/helpers/magic_test_helper.rb
+++ b/test/helpers/magic_test_helper.rb
@@ -44,4 +44,12 @@ module MagicTestHelpers
       yield(Dir.pwd)
     end
   end
+
+  def with_env(env, &blk)
+    before = ENV.to_h.dup
+    env.each { |k, v| ENV[k] = v }
+    yield
+  ensure
+    ENV.replace(before)
+  end
 end

--- a/test/test_magic.rb
+++ b/test/test_magic.rb
@@ -461,7 +461,13 @@ class MagicTest < Test::Unit::TestCase
 
     with_fixtures do
       @magic.load('png-fake.magic')
+      assert_equal(['png-fake.magic'], @magic.paths)
+      assert_match(%r{^Ruby Gem image}, @magic.file(Pathname.new('ruby.png')))
+    end
 
+    with_fixtures do
+      @magic.load('png-fake.magic', 'shell.magic')
+      assert_equal(['png-fake.magic', 'shell.magic'], @magic.paths)
       assert_match(%r{^Ruby Gem image}, @magic.file(Pathname.new('ruby.png')))
     end
   end

--- a/test/test_magic.rb
+++ b/test/test_magic.rb
@@ -189,6 +189,14 @@ class MagicTest < Test::Unit::TestCase
   end
 
   def test_magic_paths_with_MAGIC_environment_variable
+    with_fixtures do
+      magic = with_env({"MAGIC" => "png-fake.magic"}) do
+        Magic.new
+      end
+
+      assert_equal(["png-fake.magic"], magic.paths)
+      assert_match(%r{^Ruby Gem image}, magic.file(Pathname.new('ruby.png')))
+    end
   end
 
   def test_magic_get_parameter_with_PARAM_INDIR_MAX
@@ -605,6 +613,21 @@ class MagicTest < Test::Unit::TestCase
   end
 
   def test_magic_load_with_MAGIC_environment_variable
+    original_paths = @magic.paths
+
+    with_fixtures do
+      with_env({"MAGIC" => "png-fake.magic"}) do
+        # assert on setup
+        magic = Magic.new
+        assert_equal(["png-fake.magic"], magic.paths)
+        assert_match(%r{^Ruby Gem image}, magic.file(Pathname.new('ruby.png')))
+
+        # verify that #load should override the existing @paths and MAGIC
+        magic.load(original_paths)
+        assert_equal(original_paths, magic.paths)
+        assert_match(%r{^PNG image data}, magic.file(Pathname.new('ruby.png')))
+      end
+    end
   end
 
   def test_magic_load_buffers


### PR DESCRIPTION
Native gems were briefly discussed at #8 and I was able to do a little bit of work to add support for native (precompiled) gems.

To try this out, you'll need Docker installed on your system. Then:

* `bundle update` to install rake-compiler-dock
* `bundle exec rake clean`
* `bundle exec rake gem:x86_64-linux` to build that platform's native gem

I've also added `x86-linux` to this commit; but not Darwin because I had trouble getting libmagic to cross-compile (we can look into that later).

The packaged gem will the contain a `lib` directory that looks like:
- lib/magic/2.5/magic.so
- lib/magic/2.6/magic.so
- lib/magic/2.7/magic.so
- lib/magic/3.0/magic.so

Each of these is a dynamic shared library that contains a statically-linked version of libmagic, with the C extension compiled against that version of Ruby.

Let me know what you think, and I hope this is helpful.
