### PR TITLE
Relax mini_portile2 dependency

### DIFF
--- a/ext/magic/extconf.rb
+++ b/ext/magic/extconf.rb
@@ -9,7 +9,7 @@ PACKAGE_ROOT_DIR = File.expand_path(File.join(File.dirname(__FILE__), '..', '..'
 
 # The gem version constraint in the Rakefile is not respected at install time.
 # Keep this version in sync with the one in the Rakefile !
-REQUIRED_MINI_PORTILE_VERSION = "~> 2.5.0"
+REQUIRED_MINI_PORTILE_VERSION = "~> 2.6"
 
 MAGIC_HELP_MESSAGE = <<~HELP
   USAGE: ruby #{$0} [options]

--- a/ruby-magic.gemspec
+++ b/ruby-magic.gemspec
@@ -54,5 +54,5 @@ Gem::Specification.new do |s|
   s.cert_chain  = [ 'kwilczynski-public.pem' ]
   s.signing_key = signing_key if File.exist?(signing_key)
 
-  s.add_runtime_dependency("mini_portile2", "~> 2.5.0") # keep version in sync with extconf.rb
+  s.add_runtime_dependency("mini_portile2", "~> 2.6") # keep version in sync with extconf.rb
 end


### PR DESCRIPTION
This enables ruby-magic to be compatible with Nokogiri and other gems
that use a more recent version of mini_portile2.

Closes #22