### PR TITLE
Check for pkg-config when building static libraries

### DIFF
--- a/ext/magic/extconf.rb
+++ b/ext/magic/extconf.rb
@@ -298,7 +298,11 @@ else
   if static_p
     ENV['PKG_CONFIG_PATH'] = "#{libmagic_recipe.path}/lib/pkgconfig"
     # mkmf appends -- to the first option
-    $LIBS += " " + pkg_config('libmagic', 'libs --static')
+    pkg_config_flags = pkg_config('libmagic', 'libs --static')
+
+    raise 'Please install the `pkg-config` utility' unless pkg_config_flags
+
+    $LIBS += " " + pkg_config_flags
     $LIBS += " " + File.join(libmagic_recipe.path, 'lib', "libmagic.#{$LIBEXT}")
   end
 


### PR DESCRIPTION
Previously we would fail with an unclear `+: no implicit conversion of nil into String` error when the pkg-config did not run successfully. We now raise an exception to help explain why.