### PR TITLE
Pin bundler version to v2.3.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,10 +3,11 @@
     paths:
       - vendor/ruby
   before_script:
-    - gem install bundler --no-document
+    # bundler v2.3.5 appears to have some issues in CI
+    - gem install bundler -v 2.3.0 --no-document
     - bundle config set --local path 'vendor/bundle'
     - bundle config set --local without 'development'
-    - bundle install -j $(nproc) --path vendor  # Install dependencies into ./vendor/ruby
+    - bundle install -j $(nproc)
     - ruby -v                                   # Print out ruby version for debugging
   script:
     - bundle exec rake compile


### PR DESCRIPTION
For some reason, bundler version v2.3.5 appears to generate permission
denied errors and fail:
https://gitlab.com/stanhu/ruby-magic/-/jobs/1972353334