### PR TITLE
Remove workaround for linux build per RCD

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ gemspec
 
 gem 'rake'
 gem 'rake-compiler', '~> 1.1.7'
-gem 'rake-compiler-dock', '~> 1.2.0'
+gem 'rake-compiler-dock', '~> 1.2.1'
 gem 'rdoc'
 
 group :test do

--- a/ext/magic/extconf.rb
+++ b/ext/magic/extconf.rb
@@ -393,13 +393,6 @@ unless have_header('ruby.h')
   EOS
 end
 
-# these are needed for `rb_thread_call_without_gvl` to be properly detected on some linux systems.
-# specifically, rake-compiler-dock's redhat-based image needs these.
-have_library('pthread')
-have_library('rt')
-have_library('dl')
-have_library('crypt')
-
 have_func('rb_thread_call_without_gvl')
 have_func('rb_thread_blocking_region')
 


### PR DESCRIPTION
It is no longer necessary with rake-compiler-dock-1.2.1. It is fixed in https://github.com/rake-compiler/rake-compiler-dock/issues/65