### PR TITLE
Drop secure flag for FileUtils.rm_rf in extconf.rb

### DIFF
--- a/ext/magic/extconf.rb
+++ b/ext/magic/extconf.rb
@@ -319,7 +319,7 @@ else
   if cross_build_p
     # database files will be packaged up by the cross-compiling callback in the ExtensionTask
     to_path = File.join(PACKAGE_ROOT_DIR, "ext/magic/share")
-    FileUtils.rm_rf(to_path, secure: true)
+    FileUtils.rm_rf(to_path, verbose: true)
     FileUtils.mkdir(to_path)
     FileUtils.cp_r(Dir[File.join(libmagic_recipe.path, 'share/misc/*.mgc')], to_path)
   end


### PR DESCRIPTION
This was preventing files from being cleaned up in a Docker image when
building native gems. Let's just drop this for simplicity.