### PR TITLE
test_magic: ignore GC compaction test on unsupported platforms

### DIFF
--- a/test/test_magic.rb
+++ b/test/test_magic.rb
@@ -931,6 +931,10 @@ class MagicTest < Test::Unit::TestCase
       defined?(GC.verify_compaction_references) == 'method',
       "Platform does not support GC.compact"
     )
-    GC.verify_compaction_references(double_heap: true, toward: :empty)
+    begin
+      GC.verify_compaction_references(double_heap: true, toward: :empty)
+    rescue NotImplementedError => e
+      omit(e)
+    end
   end
 end


### PR DESCRIPTION
Even on Ruby versions where GC compaction is supported, it's not
supported on all platforms. For example on Debian ppc64el (PowerPC
64-bit, Little Endian).