### PR TITLE
Add --with-magic-flags option

### DIFF
--- a/ext/magic/extconf.rb
+++ b/ext/magic/extconf.rb
@@ -34,6 +34,9 @@ MAGIC_HELP_MESSAGE = <<~HELP
       --enable-cross-build
           Enable cross-build mode. (You probably do not want to set this manually.)
 
+      --with-magic-flags=<flags>
+            Build libmagic with these configure flags (such as --disable-zstdlib)
+
     Flags only used when using system libraries:
 
       Related to libmagic:
@@ -101,11 +104,16 @@ def process_recipe(name, version, static_p, cross_p)
       end
     end
 
-    recipe.configure_options = [
+    configure_options = [
       "--disable-silent-rules",
       "--disable-dependency-tracking",
       "--enable-fsect-man5"
     ]
+
+    libmagic_flags = with_config('magic-flags')
+    configure_options += libmagic_flags.split(' ') if libmagic_flags
+
+    recipe.configure_options = configure_options
 
     if static_p
       recipe.configure_options += [


### PR DESCRIPTION
libmagic v5.44 added zstd compression by default, but this may not be desired. Add an option to make it possible to tweak libmagic configure options.