### PR TITLE
Use append_cflags instead of modifying CFLAGS directly

### DIFF
--- a/ext/magic/extconf.rb
+++ b/ext/magic/extconf.rb
@@ -120,7 +120,7 @@ def process_recipe(name, version, static_p, cross_p)
         "--disable-shared",
         "--enable-static",
       ]
-      env["CFLAGS"] = concat_flags(env["CFLAGS"], "-fPIC")
+      append_cflags("-fPIC")
     else
       recipe.configure_options += [
         "--enable-shared",
@@ -332,30 +332,26 @@ else
   end
 end
 
-$CFLAGS += ' -std=c99'
+append_cflags('-std=c99')
 
 if RbConfig::CONFIG['CC'] =~ /gcc/
-  $CFLAGS += ' -O3' unless $CFLAGS =~ /-O\d/
+  append_cflags('-O3') unless $CFLAGS =~ /-O\d/
 end
 
-%w[
+append_cflags(%w[
   -Wcast-qual
   -Wwrite-strings
   -Wconversion
   -Wmissing-noreturn
   -Winline
-].select do |flag|
-  try_link('int main(void) { return 0; }', flag)
-end.each do |flag|
-  $CFLAGS += " " + flag
-end
+])
 
 unless darwin?
-  $LDFLAGS += ' -Wl,--as-needed -Wl,--exclude-libs,ALL'
+  append_ldflags(['-Wl,--as-needed', '-Wl,--exclude-libs,ALL'])
 end
 
 if windows?
-  $LDFLAGS += ' -static-libgcc'
+  append_ldflags('-static-libgcc')
 end
 
 unless have_header('ruby.h')


### PR DESCRIPTION
This fixes a compilation issue in GCC 15 due `stdbool.h` not being included when `-std=c99` is in use. This occurs because the standard `configure` script shipped with older Ruby versions (prior to 3.4.5 and 3.3.9) do not properly test for `stdbool.h` on C23 compilers (https://bugs.ruby-lang.org/issues/21340).

The `append_cflags` approach is recommended over modifying CFLAGS since it ensures compatibility across different build environments by checking whether the flag is acceptable.

Similar changes:

* https://github.com/socketry/io-event/pull/137
* https://github.com/mongodb/bson-ruby/pull/355
